### PR TITLE
fix: don't override existing highlight definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ require('local-highlight').setup({
 
 Specify the highlighting group to use.
 
-By default, `local-highlight` will use the `LocalHighlight` highlighting
-group, defined upon startup. You can use any other group you desire.
+By default, `local-highlight` will use the `LocalHighlight` highlight group, which it defines upon startup. If the group is already defined elsewhere in your config then it will not be overwritten. You can use any other group you desire.
 
 ## `cw_hlgroup`
 

--- a/lua/local-highlight.lua
+++ b/lua/local-highlight.lua
@@ -221,6 +221,7 @@ function M.setup(config)
   vim.api.nvim_set_hl(0, "LocalHighlight", {
     fg="#dcd7ba",
     bg="#2d4f67",
+    default=true
   })
 
   M.config = vim.tbl_deep_extend(


### PR DESCRIPTION
Currently, if i define `LocalHighlight` in my colorscheme, then this plugin override's it