### PR TITLE
Fix nil reference to `config` in  `setup` call without args

### DIFF
--- a/lua/local-highlight.lua
+++ b/lua/local-highlight.lua
@@ -230,10 +230,10 @@ function M.setup(config)
     M.config
   )
   local au = api.nvim_create_augroup("Highlight_usages_in_window", {clear = true})
-  if config.file_types and #(config.file_types)> 0 then
+  if M.config.file_types and #(M.config.file_types)> 0 then
     vim.api.nvim_create_autocmd('FileType', {
       group = au,
-      pattern = config.file_types,
+      pattern = M.config.file_types,
       callback = function(data)
         M.attach(data.buf)
       end


### PR DESCRIPTION
Thanks for your plugin!

This is just a very simple bugfix. I found calling `require('local-highlight').setup()` as suggested in the README, a bug occurs because this function indexes into `config`, but it's `nil` if `setup` is called in this way. Running `:PackerCompile` and opening nvim afterward gives the following error message:

```
packer.nvim: Error running config for local-highlight.nvim: ...acker/start/local-highlight.nvim/lua/local-highlight.lua:233: attempt to index local 'config' (a nil value)
```

The fix was simple: index into the updated `M.config` instead
