### PR TITLE
add disable_file_types option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ You can setup local-highlight` as follows:`
 
 ```lua
 require('local-highlight').setup({
-    file_types = {'python', 'cpp'},
+    file_types = {'python', 'cpp'}, -- If this is given only attach to this
+    -- OR attach to every filetype except:
+    disable_file_types = {'tex'}
     hlgroup = 'Search',
     cw_hlgroup = nil,
 })
@@ -56,13 +58,14 @@ By default, `local-highlight` will use the `LocalHighlight` highlight group, whi
 Specify the highlighting group to use for the word under the cursor. Defaults to
 `nil`, which means "Do not apply any highlighting".
 
-## `file_types`
+## `file_types` and `disable_file_types`
 
 The plugin works out of the box if you want to use `FileType`s to attach to
-buffers. 
+buffers.
 
 If you do not supply the `file_types` configuration option, `local-highlight` will
-attach by default to all buffers using the `BufRead` autocommand event.
+attach by default to all buffers, except those filetypes specified in
+`disable_file_types` using the `BufRead` autocommand event.
 If you set `file_types` to an empty table, `{}`, `local-highlight` will not
 attach to any buffer on its own, and will leave all attach logic to the user.
 

--- a/lua/local-highlight.lua
+++ b/lua/local-highlight.lua
@@ -7,6 +7,7 @@ local M = {
   regexes = {},
   config = {
     file_types = {},
+    disable_file_types = {},
     hlgroup = 'LocalHighlight',
     cw_hlgroup = nil,
   },
@@ -225,6 +226,11 @@ function M.setup(config)
       group = au,
       pattern = '*.*',
       callback = function(data)
+        if M.config.disable_file_types then
+          if vim.tbl_contains(M.config.disable_file_types, vim.bo.filetype) then
+            return
+          end
+        end
         M.attach(data.buf)
       end,
     })


### PR DESCRIPTION
disable_file_types is used if file_types is not set, filetypes in that list are excluded, local-highlight is not enabled
