### PR TITLE
fix: plugin is not attached to the buffer with the default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Specify the highlighting group to use for the word under the cursor. Defaults to
 The plugin works out of the box if you want to use `FileType`s to attach to
 buffers.
 
-If you do not supply the `file_types` configuration option, `local-highlight` will
+Both `file_types` and `disable_file_types` are default to `nil`, which means `local-highlight` will
 attach by default to all buffers, except those filetypes specified in
 `disable_file_types` using the `BufRead` autocommand event.
 If you set `file_types` to an empty table, `{}`, `local-highlight` will not

--- a/doc/local-highlight.txt
+++ b/doc/local-highlight.txt
@@ -100,11 +100,11 @@ FILE_TYPES AND DISABLE_FILE_TYPES*local-highlight-setup-file_types-and-disable_f
 The plugin works out of the box if you want to use `FileType`s to attach
 tobuffers.
 
-If you do not supply the `file_types` configuration option, `local-highlight`
-willattach by default to all buffers, except those filetypes specified
-in`disable_file_types` using the `BufRead` autocommand event.If you set
-`file_types` to an empty table, `{}`, `local-highlight` will notattach to any
-buffer on its own, and will leave all attach logic to the user.
+Both `file_types` and `disable_file_types` are default to `nil`, which means
+`local-highlight` will attach by default to all buffers, except those filetypes
+specified in `disable_file_types` using the `BufRead` autocommand event.
+If you set `file_types` to an empty table, `{}`, `local-highlight` will not attach
+to any buffer on its own, and will leave all attach logic to the user.
 
 
 API                                                *local-highlight-setup-api*

--- a/lua/local-highlight.lua
+++ b/lua/local-highlight.lua
@@ -6,8 +6,8 @@ local api = vim.api
 local M = {
   regexes = {},
   config = {
-    file_types = {},
-    disable_file_types = {},
+    file_types = nil,
+    disable_file_types = nil,
     hlgroup = 'LocalHighlight',
     cw_hlgroup = nil,
   },


### PR DESCRIPTION
This PR fixes following issue
- https://github.com/tzachar/local-highlight.nvim/issues/14

This is caused by incorrect evaluation due to nil table checking for `M.config.file_types`