### PR TITLE
fix: debounce_timeout config not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ Specify the highlighting group to use for the word under the cursor. Defaults to
 
 ## `debounce_timeout`
 
-The number of milliseconds to wait after a `CursorMoved` event fires to start
-the highlighting process. The default is `200`, meaning that we will only start
-highligting `200` milliseconds after the last `CursorMoved` event (last meaning
-all other events were less than `200` milliseconds apart).
+The number of milliseconds to wait after the last `CursorMoved` event fires before
+refreshing highlights. The default is `200`, meaning that highlights will be updated
+after the cursor has remained stationary for `200` milliseconds. Set to `0` to
+refresh highlights on every `CursorMoved` event, with no delay.
 
 ## `file_types` and `disable_file_types`
 


### PR DESCRIPTION
In 21f13c6cc8feb9ef9fb32313a77e9ad97eed8dc6, the `debounce_timeout` config option was added directly to `M` rather than `M.config`, which means the debounce timeout is always 200ms even if you set it differently in `setup()`.

Personally, I don't want any debouncing at all (this is one of the reasons why I have `updatetime` set to 20ms). So I also added a fast path where if `debounce_timeout` is 0 then it will skip the debounce timer and just run `highlight_usages` directly.