### PR TITLE
Fix highlighting of single match when `highlight_single_match = false`

### DIFF
--- a/lua/local-highlight.lua
+++ b/lua/local-highlight.lua
@@ -177,6 +177,7 @@ function M.highlight_usages(bufnr)
   end
 
   if not M.config.highlight_single_match and total_matches <= 1 then
+    M.clear_highlights(bufnr, M.last_cache[bufnr])
     return
   end
 


### PR DESCRIPTION
When `highlight_single_match = false` and the current word is unique, the first character of that word is going to be highlighted. Example:
<img width="623" alt="image" src="https://github.com/user-attachments/assets/61c35943-09f3-406f-8f71-dfeed820c603" />

Therefore for this case, I've resorted to still call `clear_highlights` to fix this issue.
What do you think?

Thank you!